### PR TITLE
[#113] Rename role to solrcloud_role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,19 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [Unreleased](https://github.com/idealista/solrcloud-role/tree/develop)
+## [Unreleased](https://github.com/idealista/solrcloud_role/tree/develop)
 ### Changed
-- *[#107](https://github.com/idealista/solrcloud-role/issues/107) Default naven repository using https instead of http*
-- *Bump ansible version to 2.8.8*
-- *[#110](https://github.com/idealista/solrcloud-role/issues/110) Role fully compatible with solr 8.5.1*
-- *[#109](https://github.com/idealista/solrcloud-role/issues/109) Migration to molecule 3.x*
+- *[#107](https://github.com/idealista/solrcloud_role/issues/107) Default naven repository using https instead of http*
+- *Bump ansible version to 2.8.8* @sorobon
+- *[#110](https://github.com/idealista/solrcloud_role/issues/110) Role fully compatible with solr 8.5.1* @sorobon
+- *[#109](https://github.com/idealista/solrcloud_role/issues/109) Migration to molecule 3.x* @sorobon
+- *[#113](https://github.com/idealista/solrcloud_role/issues/113) Rename role to solrcloud_role* @sorobon
 ### Fixed
-- *[#106](https://github.com/idealista/solrcloud-role/issues/106) Extra space in SOLR_ULIMIT_CHECKS var in solr.in.sh.j2*
+- *[#106](https://github.com/idealista/solrcloud_role/issues/106) Extra space in SOLR_ULIMIT_CHECKS var in solr.in.sh.j2*
 ### Removed
 - *Only one molecule test with all options*
 
-## [2.4.0](https://github.com/idealista/solrcloud-role/tree/2.4.0) (2019-11-20)
+## [2.4.0](https://github.com/idealista/solrcloud_role/tree/2.4.0) (2019-11-20)
 ### Added
 - *[#100] JVM agents support* @sorobon
 ### Changed
@@ -22,139 +23,139 @@ All notable changes to this project will be documented in this file.
 ### Removed
 - *[#98] Collection templates transfer using rsync module (no option available now)*
 
-## [2.3.0](https://github.com/idealista/solrcloud-role/tree/2.3.0) (2019-10-31)
+## [2.3.0](https://github.com/idealista/solrcloud_role/tree/2.3.0) (2019-10-31)
 ### Changed
 - *[#94] Upgrade to solr 8.2.0* @sorobon
 
-## [2.2.0](https://github.com/idealista/solrcloud-role/tree/2.2.0) (2019-06-19)
+## [2.2.0](https://github.com/idealista/solrcloud_role/tree/2.2.0) (2019-06-19)
 ### Added
-- *[#80](https://github.com/idealista/solrcloud-role/issues/80) External libs support added* @sorobon
-- *[#82](https://github.com/idealista/solrcloud-role/issues/82) Java 11 support* @sorobon
+- *[#80](https://github.com/idealista/solrcloud_role/issues/80) External libs support added* @sorobon
+- *[#82](https://github.com/idealista/solrcloud_role/issues/82) Java 11 support* @sorobon
 - *Add ability to provide custom templates via `solr_templates_dir` variable* @jnogol
 
 ### Changed
-- *[#88](https://github.com/idealista/solrcloud-role/issues/88) Change "action" tasks to use uri module instead* @jnogol
-- *[#87](https://github.com/idealista/solrcloud-role/issues/87) Default version installed is Solr 8.1.1* @jnogol
+- *[#88](https://github.com/idealista/solrcloud_role/issues/88) Change "action" tasks to use uri module instead* @jnogol
+- *[#87](https://github.com/idealista/solrcloud_role/issues/87) Default version installed is Solr 8.1.1* @jnogol
 - *Upgrade Ansible version to 2.5.15 in test-requirements to avoid CVE-2019-3828* @jnogol
 
 ### Fixed
-- *[#90](https://github.com/idealista/solrcloud-role/issues/90) Fix collection templates transfer adding copy module option* @jnogol
+- *[#90](https://github.com/idealista/solrcloud_role/issues/90) Fix collection templates transfer adding copy module option* @jnogol
 
-## [2.1.2](https://github.com/idealista/solrcloud-role/tree/2.1.2) (2019-01-30)
+## [2.1.2](https://github.com/idealista/solrcloud_role/tree/2.1.2) (2019-01-30)
 ### Changed
-- *[#72](https://github.com/idealista/solrcloud-role/issues/72) Adding cache and retries in remote package installation* @dortegau
+- *[#72](https://github.com/idealista/solrcloud_role/issues/72) Adding cache and retries in remote package installation* @dortegau
 ### Fixed
-- *[#75](https://github.com/idealista/solrcloud-role/issues/75) Logging is not working* @sorobon
+- *[#75](https://github.com/idealista/solrcloud_role/issues/75) Logging is not working* @sorobon
 
-## [2.1.1](https://github.com/idealista/solrcloud-role/tree/2.1.1) (2019-01-21)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/2.1.0...2.1.1)
+## [2.1.1](https://github.com/idealista/solrcloud_role/tree/2.1.1) (2019-01-21)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/2.1.0...2.1.1)
 ### Fixed
-- *[#67](https://github.com/idealista/solrcloud-role/issues/67) Role fails when collections aren't provided* @sorobon
+- *[#67](https://github.com/idealista/solrcloud_role/issues/67) Role fails when collections aren't provided* @sorobon
 
-## [2.1.0](https://github.com/idealista/solrcloud-role/tree/2.1.0) (2018-12-19)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/2.0.0...2.1.0)
+## [2.1.0](https://github.com/idealista/solrcloud_role/tree/2.1.0) (2018-12-19)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/2.0.0...2.1.0)
 ### Changed
-- *[#63](https://github.com/idealista/solrcloud-role/issues/63) Installing Apache Solr 7.6.0 by default* @dortegau
+- *[#63](https://github.com/idealista/solrcloud_role/issues/63) Installing Apache Solr 7.6.0 by default* @dortegau
 
-## [2.0.0](https://github.com/idealista/solrcloud-role/tree/2.0.0) (2018-12-17)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.9.0...2.0.0)
+## [2.0.0](https://github.com/idealista/solrcloud_role/tree/2.0.0) (2018-12-17)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/1.9.0...2.0.0)
 ### Added
-- *[#53](https://github.com/idealista/solrcloud-role/issues/53) Adding tasks to manage collections* @dortegau
+- *[#53](https://github.com/idealista/solrcloud_role/issues/53) Adding tasks to manage collections* @dortegau
 
 ### Changed
-- *[#58](https://github.com/idealista/solrcloud-role/issues/58) Testing against a cluster with two nodes (solrcloud1 and solrcloud2) instead of one* @dortegau
-- *[#54](https://github.com/idealista/solrcloud-role/issues/54) Installing SolrCloud 7.5.0 by default* @dortegau
-- *[#55](https://github.com/idealista/solrcloud-role/issues/55) Upgrading Java and ZooKeeper roles to latest versions, using hostmanager plugin to manage network instead of landrush, adding test-requirements.txt for execution under pipenv and upgrading to Ansible 2.5.5.0* @dortegau
+- *[#58](https://github.com/idealista/solrcloud_role/issues/58) Testing against a cluster with two nodes (solrcloud1 and solrcloud2) instead of one* @dortegau
+- *[#54](https://github.com/idealista/solrcloud_role/issues/54) Installing SolrCloud 7.5.0 by default* @dortegau
+- *[#55](https://github.com/idealista/solrcloud_role/issues/55) Upgrading Java and ZooKeeper roles to latest versions, using hostmanager plugin to manage network instead of landrush, adding test-requirements.txt for execution under pipenv and upgrading to Ansible 2.5.5.0* @dortegau
 
-## [1.9.0](https://github.com/idealista/solrcloud-role/tree/1.9.0) (2018-02-12)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.8.0...1.9.0)
+## [1.9.0](https://github.com/idealista/solrcloud_role/tree/1.9.0) (2018-02-12)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/1.8.0...1.9.0)
 ### Changed
-- *[#47](https://github.com/idealista/solrcloud-role/issues/47) Configure zookeeper client timeout* @danieljesus
-- *[#14](https://github.com/idealista/solrcloud-role/issues/14) Add Travis CI* @jnogol
+- *[#47](https://github.com/idealista/solrcloud_role/issues/47) Configure zookeeper client timeout* @danieljesus
+- *[#14](https://github.com/idealista/solrcloud_role/issues/14) Add Travis CI* @jnogol
 
-## [1.8.0](https://github.com/idealista/solrcloud-role/tree/1.8.0) (2017-09-26)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.7.0...1.8.0)
+## [1.8.0](https://github.com/idealista/solrcloud_role/tree/1.8.0) (2017-09-26)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/1.7.0...1.8.0)
 
 ### Fixed
-- *[#43](https://github.com/idealista/solrcloud-role/issues/43) Forcing XML response in admin/info request handler due to change to JSON as default response format* @dortegau
+- *[#43](https://github.com/idealista/solrcloud_role/issues/43) Forcing XML response in admin/info request handler due to change to JSON as default response format* @dortegau
 
 ### Changed
-- *[#41](https://github.com/idealista/solrcloud-role/issues/41) Upgrading to SolrCloud 7.0.0* @dortegau
+- *[#41](https://github.com/idealista/solrcloud_role/issues/41) Upgrading to SolrCloud 7.0.0* @dortegau
 
-## [1.7.0](https://github.com/idealista/solrcloud-role/tree/1.7.0) (2017-06-29)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.6.0...1.7.0)
-
-### Changed
-- *[#36](https://github.com/idealista/solrcloud-role/issues/36) Support Debian stretch* @jmonterrubio
-
-
-## [1.6.0](https://github.com/idealista/solrcloud-role/tree/1.6.0) (2017-04-24)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.5.2...1.6.0)
+## [1.7.0](https://github.com/idealista/solrcloud_role/tree/1.7.0) (2017-06-29)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/1.6.0...1.7.0)
 
 ### Changed
-- *[#30](https://github.com/idealista/solrcloud-role/issues/30) Upgrading to SolrCloud 6.5.0* @dortegau
+- *[#36](https://github.com/idealista/solrcloud_role/issues/36) Support Debian stretch* @jmonterrubio
+
+
+## [1.6.0](https://github.com/idealista/solrcloud_role/tree/1.6.0) (2017-04-24)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/1.5.2...1.6.0)
+
+### Changed
+- *[#30](https://github.com/idealista/solrcloud_role/issues/30) Upgrading to SolrCloud 6.5.0* @dortegau
 
 ### Fixed
-- *[#26](https://github.com/idealista/solrcloud-role/issues/26) Fixing configuration issues in tests when default TLD was added* @dortegau
+- *[#26](https://github.com/idealista/solrcloud_role/issues/26) Fixing configuration issues in tests when default TLD was added* @dortegau
 
 
-## [1.5.2](https://github.com/idealista/solrcloud-role/tree/1.5.2) (2017-04-21)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.5.1...1.5.2)
-
-### Fixed
-- *[#24](https://github.com/idealista/solrcloud-role/issues/24) Fixing jetty-xml configuration file (deleting values inside config sets)* @dortegau
-- *[#26](https://github.com/idealista/solrcloud-role/issues/26) Adding default TLD in molecule.yml* @dortegau
-
-## [1.5.1](https://github.com/idealista/solrcloud-role/tree/1.5.1) (2017-04-21)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.5.0...1.5.1)
+## [1.5.2](https://github.com/idealista/solrcloud_role/tree/1.5.2) (2017-04-21)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/1.5.1...1.5.2)
 
 ### Fixed
-- *[#21](https://github.com/idealista/solrcloud-role/issues/21) Fixing Acceptor/Selector thread configuration in jetty-http template* @dortegau
+- *[#24](https://github.com/idealista/solrcloud_role/issues/24) Fixing jetty-xml configuration file (deleting values inside config sets)* @dortegau
+- *[#26](https://github.com/idealista/solrcloud_role/issues/26) Adding default TLD in molecule.yml* @dortegau
 
-## [1.5.0](https://github.com/idealista/solrcloud-role/tree/1.5.0) (2017-03-31)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.4.0...1.5.0)
+## [1.5.1](https://github.com/idealista/solrcloud_role/tree/1.5.1) (2017-04-21)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/1.5.0...1.5.1)
+
+### Fixed
+- *[#21](https://github.com/idealista/solrcloud_role/issues/21) Fixing Acceptor/Selector thread configuration in jetty-http template* @dortegau
+
+## [1.5.0](https://github.com/idealista/solrcloud_role/tree/1.5.0) (2017-03-31)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/1.4.0...1.5.0)
 
 ### Added
 *Renamed some vars (backwards compatible!)* @jmonterrubio
 
 ### Fixed
-- *[#18](https://github.com/idealista/solrcloud-role/issues/18) Check version for conditional installation* @jmonterrubio
+- *[#18](https://github.com/idealista/solrcloud_role/issues/18) Check version for conditional installation* @jmonterrubio
 
-## [1.4.0](https://github.com/idealista/solrcloud-role/tree/1.4.0) (2017-03-16)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.3.0...1.4.0)
-
-### Added
-- *[#15](https://github.com/idealista/solrcloud-role/issues/15) Add jetty-http config file* @javierRobledo
-
-## [1.3.0](https://github.com/idealista/solrcloud-role/tree/1.3.0) (2017-02-23)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.2.0...1.3.0)
+## [1.4.0](https://github.com/idealista/solrcloud_role/tree/1.4.0) (2017-03-16)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/1.3.0...1.4.0)
 
 ### Added
-- *[#11](https://github.com/idealista/solrcloud-role/issues/11) Add mount folder for backup* @jmonterrubio
+- *[#15](https://github.com/idealista/solrcloud_role/issues/15) Add jetty-http config file* @javierRobledo
 
-## [1.2.0](https://github.com/idealista/solrcloud-role/tree/1.2.0) (2017-01-27)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.1.1...1.2.0)
+## [1.3.0](https://github.com/idealista/solrcloud_role/tree/1.3.0) (2017-02-23)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/1.2.0...1.3.0)
 
 ### Added
-- *[#8](https://github.com/idealista/solrcloud-role/issues/8) Set JVM args by configuration* @jmonterrubio
+- *[#11](https://github.com/idealista/solrcloud_role/issues/11) Add mount folder for backup* @jmonterrubio
 
-## [1.1.1](https://github.com/idealista/solrcloud-role/tree/1.1.1) (2017-01-11)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.1.0...1.1.1)
+## [1.2.0](https://github.com/idealista/solrcloud_role/tree/1.2.0) (2017-01-27)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/1.1.1...1.2.0)
+
+### Added
+- *[#8](https://github.com/idealista/solrcloud_role/issues/8) Set JVM args by configuration* @jmonterrubio
+
+## [1.1.1](https://github.com/idealista/solrcloud_role/tree/1.1.1) (2017-01-11)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/1.1.0...1.1.1)
 
 ### Fixed
-- *[#4](https://github.com/idealista/solrcloud-role/issues/4) Copy solr.xml file for not default data dir* @jmonterrubio
+- *[#4](https://github.com/idealista/solrcloud_role/issues/4) Copy solr.xml file for not default data dir* @jmonterrubio
 
-## [1.1.0](https://github.com/idealista/solrcloud-role/tree/1.1.0)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.0.1...1.1.0)
+## [1.1.0](https://github.com/idealista/solrcloud_role/tree/1.1.0)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/1.0.1...1.1.0)
 
 ### Added
-- *[#1](https://github.com/idealista/solrcloud-role/issues/1) Enable all the jetty HttpConfiguration parameters from ansible* @jmonterrubio
+- *[#1](https://github.com/idealista/solrcloud_role/issues/1) Enable all the jetty HttpConfiguration parameters from ansible* @jmonterrubio
 
 ### Fixed
-- *Renamed solrcloud-role in tests playbook* @jmonterrubio
+- *Renamed solrcloud_role in tests playbook* @jmonterrubio
 
-## [1.0.1](https://github.com/idealista/solrcloud-role/tree/1.0.1)
-[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.0.0...1.0.1)
+## [1.0.1](https://github.com/idealista/solrcloud_role/tree/1.0.1)
+[Full Changelog](https://github.com/idealista/solrcloud_role/compare/1.0.0...1.0.1)
 
 ### Fixed
 - *JMX enable* @jmonterrubio
@@ -165,6 +166,6 @@ All notable changes to this project will be documented in this file.
 - *Code refactor* @jmonterrubio
 - *Update SolrCloud sources repository* @jmonterrubio
 
-## [1.0.0](https://github.com/idealista/solrcloud-role/tree/1.0.0)
+## [1.0.0](https://github.com/idealista/solrcloud_role/tree/1.0.0)
 ### Added
 - *First commit* @jmonterrubio

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![Logo](https://raw.githubusercontent.com/idealista/solrcloud-role/master/logo.gif)
+![Logo](https://raw.githubusercontent.com/idealista/solrcloud_role/master/logo.gif)
 
-[![Build Status](https://travis-ci.org/idealista/solrcloud-role.png)](https://travis-ci.org/idealista/solrcloud-role)
+[![Build Status](https://travis-ci.org/idealista/solrcloud_role.png)](https://travis-ci.org/idealista/solrcloud_role)
 
 # SolrCloud Ansible role
 
@@ -36,7 +36,7 @@ For testing purposes, [Molecule](https://molecule.readthedocs.io/) with [Docker]
 Create or add to your roles dependency file (e.g requirements.yml):
 
 ```
-- src: idealista.solrcloud-role
+- src: idealista.solrcloud_role
   version: x.x.x
   name: solrcloud
 ```
@@ -56,10 +56,10 @@ Use in a playbook:
     - { role: solrcloud }
 ```
 
-Playbook example below showing how to provision from scratch a SolrCloud cluster with two nodes plus create an example (and empty) collection called `sample_techproducts_configs`, using idealista [java](https://github.com/idealista/java-role), [zookeeper](https://github.com/idealista/zookeeper-role) and [solrcloud](https://github.com/idealista/solrcloud-role) roles:
+Playbook example below showing how to provision from scratch a SolrCloud cluster with two nodes plus create an example (and empty) collection called `sample_techproducts_configs`, using idealista [java](https://github.com/idealista/java-role), [zookeeper](https://github.com/idealista/zookeeper-role) and [solrcloud](https://github.com/idealista/solrcloud_role) roles:
 
-**Note:** Assuming that 'solrcloud' group has two nodes (`solrcloud1` and `solrcloud2`) as is declared in [molecule.yml](https://github.com/idealista/solrcloud-role/tree/master/molecule/default/molecule.yml),
-collection will have two shards, one replica and one shard per node as is declared in group vars file called [solrcloud.yml](https://github.com/idealista/solrcloud-role/tree/master/molecule/default/group_vars/solrcloud.yml)
+**Note:** Assuming that 'solrcloud' group has two nodes (`solrcloud1` and `solrcloud2`) as is declared in [molecule.yml](https://github.com/idealista/solrcloud_role/tree/master/molecule/default/molecule.yml),
+collection will have two shards, one replica and one shard per node as is declared in group vars file called [solrcloud.yml](https://github.com/idealista/solrcloud_role/tree/master/molecule/default/group_vars/solrcloud.yml)
 and configuration files are stored under directory called `sample_techproducts_configs` under template directory.
 
 > :warning: Use the example below just as a reference, requires inventory host groups `solr` and `zookeeper` to be correctly defined
@@ -81,7 +81,7 @@ and configuration files are stored under directory called `sample_techproducts_c
 
 - hosts: solrcloud
   roles:
-    - role: solrcloud-role
+    - role: solrcloud_role
 ```
 
 ## Usage
@@ -135,9 +135,9 @@ or
 
 http://localhost:8984/solr/#/ (node: `solrcloud2`)
 
-<img src="https://raw.githubusercontent.com/idealista/solrcloud-role/master/assets/solr_admin_ui.png" alt="Solr Admin UI example" style="width: 600px;"/>
+<img src="https://raw.githubusercontent.com/idealista/solrcloud_role/master/assets/solr_admin_ui.png" alt="Solr Admin UI example" style="width: 600px;"/>
 
-See [molecule.yml](https://github.com/idealista/solrcloud-role/blob/master/molecule/default/molecule.yml) to check possible testing platforms.
+See [molecule.yml](https://github.com/idealista/solrcloud_role/blob/master/molecule/default/molecule.yml) to check possible testing platforms.
 
 ## Built With
 
@@ -145,15 +145,15 @@ See [molecule.yml](https://github.com/idealista/solrcloud-role/blob/master/molec
 
 ## Versioning
 
-For the versions available, see the [tags on this repository](https://github.com/idealista/solrcloud-role/tags).
+For the versions available, see the [tags on this repository](https://github.com/idealista/solrcloud_role/tags).
 
-Additionaly you can see what change in each version in the [CHANGELOG.md](https://github.com/idealista/solrcloud-role/blob/master/CHANGELOG.md) file.
+Additionaly you can see what change in each version in the [CHANGELOG.md](https://github.com/idealista/solrcloud_role/blob/master/CHANGELOG.md) file.
 
 ## Authors
 
 * **Idealista** - *Work with* - [idealista](https://github.com/idealista)
 
-See also the list of [contributors](https://github.com/idealista/solrcloud-role/contributors) who participated in this project.
+See also the list of [contributors](https://github.com/idealista/solrcloud_role/contributors) who participated in this project.
 
 ## License
 
@@ -163,4 +163,4 @@ This project is licensed under the [Apache 2.0](https://www.apache.org/licenses/
 
 ## Contributing
 
-Please read [CONTRIBUTING.md](https://github.com/idealista/solrcloud-role/blob/master/.github/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+Please read [CONTRIBUTING.md](https://github.com/idealista/solrcloud_role/blob/master/.github/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,4 +4,4 @@
   hosts: solrcloud
   serial: 100%
   roles:
-    - role: solrcloud-role
+    - role: solrcloud_role


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Following the Ansible Role name standards, this role should be renamed to "solrcloud_role" instead of "solrcloud-role".

### Applicable Issues

#113 